### PR TITLE
add cubitExportSTL.py and add usage instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # level-gen
+
+### How to use cubitExportSTL.py
+This module will export all groups in cubit into .stl files AND create a .json file, which can be used as input for stl_to_tscn.py
+1. Open Cubit and import the cubitExportSTL module
+```
+import sys
+sys.path.append(“<folder that contains cubitExportSTL.py>”)
+import cubitExportSTL
+```
+2. Create groups of Volumes. Each group will be exported to its own .stl file.
+3. Run this in Cubit:
+`cubitExportSTL.export_groups(cubit, "<folder to export stl files and .json file to>")`

--- a/stl_to_obj/cubitExportSTL.py
+++ b/stl_to_obj/cubitExportSTL.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import json
+
+def export_groups(cubit, output_folder):
+    # json file dictionaries
+    header_dict = {
+        "input_folder": "",
+        "output_folder": "",
+        "scale": 0.01,
+        "extra_textures": "more_textures.json" 
+    }
+    meshes = []
+
+    # get tuples of (group_name, id)
+    groups = cubit.group_names_ids()
+
+    for group in groups:
+        group_name = group[0]
+        stl_filepath = Path(output_folder) / Path(group_name).with_suffix('.stl')
+        volumes = cubit.get_group_volumes(group[1])
+        cubit.cmd(f'export stl "{stl_filepath}" volume {str(volumes)[1:-1]} overwrite')
+
+        # add .stl mesh entry to .json file
+        mesh_dict = {
+            "stl_file": f"{group_name}.stl",
+            "uv_map": "cube",
+            "texture": "Plaster", 
+            "collisions": True,
+            "mesh_compression": "limited_dissolve"
+        }
+        meshes.append(mesh_dict)
+
+    json_dict = {
+        "header": header_dict,
+        "meshes": meshes
+    }
+
+    with open(Path(output_folder) / Path("input").with_suffix('.json'), 'w') as json_file:
+        json_string = json.dumps(json_dict, indent = 4)
+        json_file.write(json_string)


### PR DESCRIPTION
I wrote a new script `cubitExportSTL.py` to help with the Cubit --> Godot pipeline. This script exports each group in Cubit into an .stl file. It also generates `input.json`, which can be used as an input to `stl_to_tscn.py`. Note that the user still has to manually create the groups in Cubit, and that's not changing regardless of whether I put it in my function call or not. 

This addition addresses the following concerns:
### Concern 1: users won't want to write out the .json file.
This concern is partially taken care of by the generated `input.json` file. Right now, it functions as a template file which users can edit/customize to set textures, uv maps, etc. for each .stl file. 

### Concern 2: Why not allow users to set parameters like `texture`, `uv_map`, etc. in the function call, or as part of the group name?
1. Adding it to the function call would make it too big. 
2. If we use some sort of input file to specify these things, then we're just reinventing `input.json`. 
3. Using group name isn't sophisticated. 🍵 

The main benefit in adding this feature would be in the case where:
- a user generates the .stl files
- then customizes `input.json`
- then regenerates the .stl files, but would like to keep the changes in `input.json`

If the user never changes the groups/regenerates the .stl files, then there's no point in adding these features because he could just customize `input.json` after using `cubitExportSTL.py`.

### Idea: create a GUI to quickly modify `input.json`
My current idea is to create a GUI that will read in a .json file, then display all the meshes in a scroll box. Then, a user could select any number of the meshes and apply a certain feature to those meshes (ex. make all of those meshes use a `uv_map` of `cube`). The GUI would then write to .json file to apply those changes. 
Benefits:
- it's faster than typing out the changes. 
- it helps with situations where you need to try a bunch of different settings to see which `uv_map` or `mesh_compression` works the best. 

The problem with this is that it fragments the pipeline into 3 phases:
1. generate .stl files with Cubit
2. (optional) edit .json file with GUI
3. generate .tscn file

Ultimately, I think that some of these complexities won't go away, and the user will **have** to do some amount of work. The best we can do is to ensure that users only need to make high level choices and won't be bogged down by drudgery. 