### PR TITLE
CSV input and command line Cubit exporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,20 @@
 # level-gen
 
-### How to use cubitExportSTL.py
-This module will export all groups in cubit into .stl files AND create a .json file, which can be used as input for stl_to_tscn.py
+## How to use cubitExportSTL.py
+This module will export all groups in cubit into .stl files AND create a template file, which can be used as input for stl_to_tscn.py
+### To export groups for an ACIS (.sat) file that already has groups
+`python3 cubitExportSTL.py [output_folder] [sat_file location] [template type]` 
+This allows you to do everything from the command line. (You don't have to open Cubit.)
+
+### To export groups while using Cubit GUI
 1. Open Cubit and import the cubitExportSTL module
+`import cubitExportSTL`
+If you get a `ModuleNotFoundError`, you can either run this:
 ```
 import sys
 sys.path.append(“<folder that contains cubitExportSTL.py>”)
-import cubitExportSTL
 ```
+or search up a way to add the folder that contains the module to your PATH env variable. 
 2. Create groups of Volumes. Each group will be exported to its own .stl file.
 3. Run this in Cubit:
 `cubitExportSTL.export_groups(cubit, "<folder to export stl files and .json file to>")`

--- a/stl_to_obj/cubitExportSTL.py
+++ b/stl_to_obj/cubitExportSTL.py
@@ -73,15 +73,14 @@ def export_groups(output_folder, template='.csv'):
             json_file.write(json_string)
     # default is .csv file
     else:
-        # write the header dict
         with open(Path(output_folder) / Path("input").with_suffix('.csv'), 'w', newline='',) as csv_file:
+            # write the header dict
             fieldnames = ["input_folder", "output_folder", "scale", "extra_textures"]
             writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
             writer.writeheader()
             writer.writerow(header_dict)
 
-        # write the meshes array
-        with open(Path(output_folder) / Path("input").with_suffix('.csv'), 'a', newline='') as csv_file:
+            # write the meshes array
             fieldnames = ["stl_file", "uv_map", "texture", "collisions", "mesh_compression"]
             writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
             writer.writeheader()
@@ -92,14 +91,10 @@ def main():
     parser = argparse.ArgumentParser(prog = "export groups in ACIS file to .stl files")
     parser.add_argument("output_folder", type = str, help = "location to store .stl and template files")
     parser.add_argument("sat_file", type = str, help = "location of ACIS file")
-    parser.add_argument("--template", "-t", type = str, help = "type of output template file (.json or .csv)")
+    parser.add_argument("--template", "-t", type = str, default=".csv", help = "type of output template file (.json or .csv)")
     args = parser.parse_args()
 
-    if args.template:
-        export_groups_CL(args.output_folder, args.sat_file, args.template)
-    else:
-        export_groups_CL(args.output_folder, args.sat_file)
-
+    export_groups_CL(args.output_folder, args.sat_file, args.template)
 
 if __name__ == "__main__":
     main()

--- a/stl_to_obj/cubitExportSTL.py
+++ b/stl_to_obj/cubitExportSTL.py
@@ -1,7 +1,37 @@
 from pathlib import Path
+import argparse
 import json
+import csv
 
-def export_groups(cubit, output_folder):
+import cubit
+
+def export_groups_CL(output_folder, sat_file, template='.csv'):
+    """ Used in terminal to export .stl files based on the groups of an ACIS file.
+    Also generates a .json file which is a template input to the stl_to_tscn module.
+
+    Parameters
+    ----------
+    output_folder : str
+        where output .stl and .json files should be placed
+    sat_file : str
+        the ACIS file
+    template : str
+        the file format of the template file (either .json or .csv)
+    """
+    cubit.cmd(f'import acis "{sat_file}" nofreesurfaces heal attributes_on separate_bodies')
+    export_groups(output_folder, template)
+
+def export_groups(output_folder, template='.csv'):
+    """ Used in Cubit's Python command line to export .stl files based on the groups of an ACIS file.
+    Also generates a .json file which is a template input to the stl_to_tscn module.
+
+    Parameters
+    ----------
+    output_folder : str
+        where output .stl and .json files should be placed
+    template : str
+        the file format of the template file (either .json or .csv)
+    """
     # json file dictionaries
     header_dict = {
         "input_folder": "",
@@ -16,6 +46,8 @@ def export_groups(cubit, output_folder):
 
     for group in groups:
         group_name = group[0]
+        if group_name == "picked":
+            continue
         stl_filepath = Path(output_folder) / Path(group_name).with_suffix('.stl')
         volumes = cubit.get_group_volumes(group[1])
         cubit.cmd(f'export stl "{stl_filepath}" volume {str(volumes)[1:-1]} overwrite')
@@ -24,7 +56,7 @@ def export_groups(cubit, output_folder):
         mesh_dict = {
             "stl_file": f"{group_name}.stl",
             "uv_map": "cube",
-            "texture": "Plaster", 
+            "texture": group_name, 
             "collisions": True,
             "mesh_compression": "limited_dissolve"
         }
@@ -35,6 +67,39 @@ def export_groups(cubit, output_folder):
         "meshes": meshes
     }
 
-    with open(Path(output_folder) / Path("input").with_suffix('.json'), 'w') as json_file:
-        json_string = json.dumps(json_dict, indent = 4)
-        json_file.write(json_string)
+    if template == '.json':
+        with open(Path(output_folder) / Path("input").with_suffix('.json'), 'w') as json_file:
+            json_string = json.dumps(json_dict, indent = 4)
+            json_file.write(json_string)
+    # default is .csv file
+    else:
+        # write the header dict
+        with open(Path(output_folder) / Path("input").with_suffix('.csv'), 'w', newline='',) as csv_file:
+            fieldnames = ["input_folder", "output_folder", "scale", "extra_textures"]
+            writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerow(header_dict)
+
+        # write the meshes array
+        with open(Path(output_folder) / Path("input").with_suffix('.csv'), 'a', newline='') as csv_file:
+            fieldnames = ["stl_file", "uv_map", "texture", "collisions", "mesh_compression"]
+            writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+            writer.writeheader()
+            for mesh in meshes:
+                writer.writerow(mesh)
+
+def main():
+    parser = argparse.ArgumentParser(prog = "export groups in ACIS file to .stl files")
+    parser.add_argument("output_folder", type = str, help = "location to store .stl and template files")
+    parser.add_argument("sat_file", type = str, help = "location of ACIS file")
+    parser.add_argument("--template", "-t", type = str, help = "type of output template file (.json or .csv)")
+    args = parser.parse_args()
+
+    if args.template:
+        export_groups_CL(args.output_folder, args.sat_file, args.template)
+    else:
+        export_groups_CL(args.output_folder, args.sat_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/stl_to_obj/stl_to_tscn.py
+++ b/stl_to_obj/stl_to_tscn.py
@@ -267,7 +267,7 @@ def csvToDict(csv_filepath):
         meshes = []
         reader = csv.DictReader(StringIO(meshes_string))
         for row in reader:
-            if row["collisions"].casefold() == "true".casefold():
+            if row["collisions"].casefold() == "true":
                 row["collisions"] = True
             else:
                 row["collisions"] = False

--- a/stl_to_obj/stl_to_tscn.py
+++ b/stl_to_obj/stl_to_tscn.py
@@ -1,6 +1,8 @@
-import argparse
 from pathlib import Path
+from io import StringIO
+import argparse
 import json
+import csv
 import shutil
 import warnings
 
@@ -245,16 +247,48 @@ def make_folder(folder):
         shutil.rmtree(p) # delete folder and contents
         p.mkdir()
 
+def csvToDict(csv_filepath):
+    with open(csv_filepath) as csv_file:
+        # split csv_file into two strings
+        # header is the first 2 lines, meshes is the rest.
+        csv_list = list(csv_file)
+        header_string = f'{csv_list[0]}\n{csv_list[1]}'
+        csv_list.pop(0)
+        csv_list.pop(0)
+        meshes_string = '\n'.join(csv_list)
+
+        # create header dict
+        reader = csv.DictReader(StringIO(header_string))
+        for row in reader:
+            row["scale"] = float(row["scale"])
+            header = row # there should only be one row in reader, that's why this works
+
+        # create meshes array
+        meshes = []
+        reader = csv.DictReader(StringIO(meshes_string))
+        for row in reader:
+            if row["collisions"].casefold() == "true".casefold():
+                row["collisions"] = True
+            else:
+                row["collisions"] = False
+            meshes.append(row)
+        
+    return {"header": header, "meshes": meshes}
 
 def main():
-    # argparse to take in input.txt
     parser = argparse.ArgumentParser(prog = ".stl to .obj and .tscn file converter")
-    parser.add_argument("input_file", type = str, help = "input json filename")
+    parser.add_argument("input_file", type = str, help = "input filename (.json or .csv)")
     args = parser.parse_args()
 
-    # load input json dictionary
-    with open(args.input_file, 'r') as f:
-        data = json.load(f)
+    # load data dictionary differently based on whether it is .json or .csv
+    inputSuffix = Path(args.input_file).suffix
+    if inputSuffix == ".json":
+        with open(args.input_file, 'r') as f:
+            data = json.load(f)
+    elif inputSuffix == ".csv":
+        data = csvToDict(args.input_file)
+    else:
+        raise Exception("input file was not a .json or .csv file")
 
     header = data["header"]
     input_folder = header["input_folder"]


### PR DESCRIPTION
### `export_groups_CL()`
A new function in `cubitExportSTL.py` which allows users to input an ACIS files with groups and export the .stl and template files without having to open Cubit. The `CL` stands for command line. Let me know if I should rename the function.

### .csv input file
I added `csvToDict()` in `stl_to_tscn.py` to convert .csv files into a dict in the same format as the original .json input files. This means users can now use a input .csv file instead of a .json file. This change was motivated by the fact that .csv files are easier to edit than .json files because you can open them in Excel. 

I also added a parameter in the functions of `cubitExportSTL.py` to allow users to either generate a .json or .csv template file. 